### PR TITLE
Fix for Beat Saber v1.29.4

### DIFF
--- a/HarmonyPatches/Smoother.cs
+++ b/HarmonyPatches/Smoother.cs
@@ -12,13 +12,12 @@ namespace SmoothedController.HarmonyPatches {
 		public float angleVelocitySnap = 1f;
 	}
 
-	[HarmonyPatch(typeof(VRController), "Update")]
 	public static class Smoother {
 		public static bool enabled = true;
 
 		static Dictionary<XRNode, wrapper> idk = new Dictionary<XRNode, wrapper>();
 
-		static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions) {
+		internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions) {
 			if(!ILUtil.CheckIL(instructions, new Dictionary<int, OpCode>() {
 				{50, OpCodes.Ldarg_0},
 				{51, OpCodes.Ldfld},
@@ -63,7 +62,7 @@ namespace SmoothedController.HarmonyPatches {
 			}
 		}
 
-		static void Prefix(VRController __instance, VRControllerTransformOffset ____transformOffset) {
+		internal static void Prefix(VRController __instance) {
 			// Check if the VRController's gameObject name starts with "C" (Controller) so that sabers (LeftHand / RightHand) are not smoothed lmao
 			if(__instance.gameObject.name[0] != 'C') {
 				instance = null;
@@ -72,5 +71,7 @@ namespace SmoothedController.HarmonyPatches {
 
 			instance = __instance;
 		}
+
+		internal static void Postfix() => YES();
 	}
 }

--- a/SmoothedController.csproj
+++ b/SmoothedController.csproj
@@ -46,7 +46,7 @@
       <HintPath>$(BeatSaberDir)\Libs\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="BSML">
-      <HintPath>E:\SteamLibrary\steamapps\common\Beat Saber\Plugins\BSML.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Plugins\BSML.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -54,24 +54,20 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Main">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
+    <Reference Include="Hive.Versioning">
+      <HintPath>$(BeatSaberDir)\Libs\Hive.Versioning.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="HMLib">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMLib.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="HMUI">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMUI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="IPA.Loader">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Unity.TextMeshPro">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+    <Reference Include="SemVer">
+      <HintPath>$(BeatSaberDir)\Libs\SemVer.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine">
@@ -82,27 +78,8 @@
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.UI">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.UIElementsModule">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UIElementsModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.UIModule">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UIModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.VRModule">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.VRModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="UnityEngine.XRModule">
-      <HintPath>E:\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.XRModule.dll</HintPath>
-    </Reference>
-    <Reference Include="VRUI">
-      <HintPath>E:\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\VRUI.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.XRModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/manifest.json
+++ b/manifest.json
@@ -3,11 +3,11 @@
     "id": "SmoothedController",
     "name": "SmoothedController",
     "author": "Kinsi55",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "Smoothes your Controller position while in menus to make it less shaky, making the UI easier to use, etc. ",
     "gameVersion": "1.16.0",
     "dependsOn": {
-        "BSIPA": "^4.0.5",
+        "BSIPA": "^4.2.1",
         "BeatSaberMarkupLanguage": "^1.4.5"
     }
 }


### PR DESCRIPTION
I didn't address it but the patch was originally failing due to `ILUtil` methods throwing when the instructions collection size is less than the passed index.